### PR TITLE
Changing output paths and bgzipping

### DIFF
--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -22,7 +22,7 @@ def create_sfs_dict(inpath):
     files = glob.glob(inpath + "**/*.vcf.gz", recursive=True)
 
     for filename in tqdm.tqdm(files):
-        print(filename)
+        # print(filename)
 
         # Load in VCF file
         my_vcf = VCF(filename)

--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -24,7 +24,7 @@ def create_sfs_dict(inpath):
     for filename in tqdm.tqdm(files):
         # print(filename)
 
-        if filename.endswith(".vcf"):
+        if filename.endswith(".vcf.gz"):
             # print(filename)
 
             # Load in VCF file

--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -4,12 +4,14 @@
 # for each one, uses the site-frequency spectrum to calculate Ne
 # from both Watterson and Pi. Exports results as single CSV.
 
-from cyvcf2 import VCF
-import tqdm
-import SFS as SFS
 import csv
 import argparse
+
 import glob
+from cyvcf2 import VCF
+from tqdm import tqdm
+
+import SFS as SFS
 from create_output_directory import create_output_directory
 
 
@@ -21,7 +23,7 @@ def create_sfs_dict(inpath):
     # Get files from inpath
     files = glob.glob(inpath + "**/*.vcf.gz", recursive=True)
 
-    for filename in tqdm.tqdm(files):
+    for filename in tqdm(files):
         # print(filename)
 
         # Load in VCF file

--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -5,7 +5,6 @@
 # from both Watterson and Pi. Exports results as single CSV.
 
 from cyvcf2 import VCF
-import os
 import tqdm
 import SFS as SFS
 import csv

--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -10,6 +10,7 @@ import tqdm
 import SFS as SFS
 import csv
 import argparse
+import glob
 from create_output_directory import create_output_directory
 
 
@@ -19,49 +20,46 @@ def create_sfs_dict(inpath):
     sfs_dict = {}
 
     # Get files from inpath
-    files = os.listdir(inpath)
+    files = glob.glob(inpath + "**/*.vcf.gz", recursive=True)
 
     for filename in tqdm.tqdm(files):
-        # print(filename)
+        print(filename)
 
-        if filename.endswith(".vcf.gz"):
-            # print(filename)
+        # Load in VCF file
+        my_vcf = VCF(filename)
 
-            # Load in VCF file
-            my_vcf = VCF(inpath + '/' + filename)
+    #     # Split VCF filename and split to extract population size, bottleneck and generation
+        split_filename = filename.split('/')[-1].split('_')
+        N_sims = int(split_filename[0].split('N')[1])
+        bot = float(split_filename[1].split('bot')[1])
+        gen = int(split_filename[2].split('gen')[1].split('.')[0])
+        # print(N_sims, bot, gen)
+        N_samples = len(my_vcf.samples)
 
-            # Split VCF filename and split to extract population size, bottleneck and generation
-            split_filename = filename.split('_')
-            N_sims = int(split_filename[0].split('N')[1])
-            bot = float(split_filename[1].split('bot')[1])
-            gen = int(split_filename[2].split('gen')[1].split('.')[0])
-            # print(N_sims, bot, gen)
-            N_samples = len(my_vcf.samples)
+        # Initialize list for sfs
+        sfs_list = [0] * ((2 * N_samples) + 1)
 
-            # Initialize list for sfs
-            sfs_list = [0] * ((2 * N_samples) + 1)
+        # Add singletons, doubletons, ...n-tons
+        for variant in my_vcf:
+            AC = variant.INFO.get('AC')
+            sfs_list[AC] += 1
 
-            # Add singletons, doubletons, ...n-tons
-            for variant in my_vcf:
-                AC = variant.INFO.get('AC')
-                sfs_list[AC] += 1
+        # Add invariant sites to sfs list
+        ch_length = 1e8
+        sfs_list[0] = int(ch_length - sum(sfs_list))
+        # print(sfs_list)
 
-            # Add invariant sites to sfs list
-            ch_length = 1e8
-            sfs_list[0] = int(ch_length - sum(sfs_list))
-            # print(sfs_list)
+        # Use sfs list to instantiate SFS class (Rob's code)
+        sfs = SFS.SFS(sfs_list)
 
-            # Use sfs list to instantiate SFS class (Rob's code)
-            sfs = SFS.SFS(sfs_list)
+        # Create string for dictionary key
+        l1 = str(N_sims) + '-' + str(bot)
 
-            # Create string for dictionary key
-            l1 = str(N_sims) + '-' + str(bot)
-
-            # Add SFS class instances to appropriate dictionary keys.
-            if l1 in sfs_dict:
-                sfs_dict[l1][gen] = sfs
-            else:
-                sfs_dict[l1] = {gen: sfs}
+        # Add SFS class instances to appropriate dictionary keys.
+        if l1 in sfs_dict:
+            sfs_dict[l1][gen] = sfs
+        else:
+            sfs_dict[l1] = {gen: sfs}
 
     return(sfs_dict)
 

--- a/scripts/python/Ne_from_SLiM_vcfs.py
+++ b/scripts/python/Ne_from_SLiM_vcfs.py
@@ -62,7 +62,7 @@ def create_sfs_dict(inpath):
         else:
             sfs_dict[l1] = {gen: sfs}
 
-    return(sfs_dict)
+    return sfs_dict
 
 
 def write_thetaNe_values(sfs_dict, outpath):

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -6,8 +6,6 @@
 
 import subprocess
 import argparse
-import os
-import tqdm
 from create_output_directory import create_output_directory
 
 

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -6,6 +6,8 @@
 
 import subprocess
 import argparse
+import os
+import tqdm
 from create_output_directory import create_output_directory
 
 
@@ -24,6 +26,29 @@ def run_slim(N, bot, outpath, slim_path):
     # err is error message from slim
     # print(out)  # calls function to parse the output
     print(err)  # prints error message
+
+
+def bgzip(outpath):
+
+    # Get files from inpath
+    files = os.listdir(outpath)
+
+    # Iterate over vcfs
+    for filename in tqdm.tqdm(files):
+
+        if filename.endswith(".vcf"):
+
+            # Full path to file
+            filepath = outpath + filename
+
+            # bgzip vcfs
+            process = subprocess.Popen(['bgzip', '-f', str(filepath)],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+    out, err = process.communicate()
+
+    print(err)
 
 
 if __name__ == "__main__":
@@ -45,3 +70,6 @@ if __name__ == "__main__":
 
     # Run simulations
     run_slim(N, bot, outpath, slim_path)
+
+    # bgzip files
+    bgzip(outpath)

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -30,24 +30,15 @@ def run_slim(N, bot, outpath, slim_path):
 
 def bgzip(outpath):
 
-    # Get files from inpath
-    files = os.listdir(outpath)
+    process = subprocess.Popen('ls {0} | xargs -n1 bgzip'.format(str(outpath) + '*.vcf'),
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               universal_newlines=True,
+                               shell=True)
 
-    # Iterate over vcfs
-    for filename in tqdm.tqdm(files):
-
-        if filename.endswith(".vcf"):
-
-            # Full path to file
-            filepath = outpath + filename
-
-            # bgzip vcfs
-            process = subprocess.Popen(['bgzip', '-f', str(filepath)],
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE,
-                                       universal_newlines=True)
     out, err = process.communicate()
 
+    # print(out)
     print(err)
 
 

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -14,7 +14,7 @@ def run_slim(N, bot, outpath, slim_path):
     # Call SLiM from command line with N and bottleneck proportion values
     # (passed as command-line arguments)
     outpath = "'" + outpath + "'"  # Required for command-line parsing and passing to SLiM
-    process = subprocess.Popen(["slim", "-d", "N=" + str(N), "-d", "bot=" + str(bot), "-d", "outpath=" + str(outpath), slim_path],
+    process = subprocess.Popen(["slim", "-d", "N=" + str(N), "-d", "bot=" + str(bot), "-d", "outpath=" + outpath, slim_path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
                                universal_newlines=True)
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     N = args.N
     bot = args.bot
     slim_path = args.slim_path
-    outpath = args.outpath
+    outpath = str(args.outpath) + "N{0}_bot{1}/".format(N, bot)
 
     # Create output directory, if it doesn't exit
     create_output_directory(outpath)

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -6,6 +6,7 @@
 
 import subprocess
 import argparse
+
 from create_output_directory import create_output_directory
 
 

--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -28,13 +28,19 @@ def run_slim(N, bot, outpath, slim_path):
 
 def bgzip(outpath):
 
-    process = subprocess.Popen('ls {0} | xargs -n1 bgzip'.format(str(outpath) + '*.vcf'),
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               universal_newlines=True,
-                               shell=True)
+    # Find all VCFs in outpath
+    process_find = subprocess.Popen(['find', outpath, '-name', '*.vcf'],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    universal_newlines=True)
 
-    out, err = process.communicate()
+    # bgzip all found VCFs
+    process_bgzip = subprocess.Popen(['xargs', '-n1', 'bgzip', '-f'],
+                                     stdin=process_find.stdout,
+                                     stderr=subprocess.PIPE,
+                                     universal_newlines=True)
+
+    out, err = process_bgzip.communicate()
 
     # print(out)
     print(err)


### PR DESCRIPTION
Meant to do this as two separate PRs (output directories + bgzipping) but I committed to the wrong branch and decided to role with it rather than resetting. 

Closes #5

- Wrote function to bgzip VCF files after they're generated
- Changed CSV generating script to have cyvcf2 read bgzipped files.

Closes #13 

- Created separate output directories for SLiM simulations based on parameter combinations
- Changed CSV generating script to recursively load bgzipped VCFs from newly created output directories. 

I think it's nicer having separate output directories for two reasons:

1. It's cleaner
2. Parameter combinations that take different lengths of time to run (e.g., N = 10 vs. N = 1000) are more self contained. This avoids functions that rely on file extensions from operating on files created by a different set of simulations when they're being run in parallel. 