### PR TITLE
Adding sequence length functionality

### DIFF
--- a/scripts/python/SLiM_sims.py
+++ b/scripts/python/SLiM_sims.py
@@ -15,14 +15,20 @@ from create_output_directory import create_output_directory
 import slim_vcf2fasta_chrom
 
 
-def run_slim(N, bot, outpath, slim_path):
+def run_slim(N, bot, region, outpath, slim_path):
 
     print("Running SLiM simulations with N={0} and bot={1}. VCFs in {2}".format(N, bot, outpath))
+
+    # Calculate length of sequence from 'region' provided at command-line
+    coords = region.split(':')[1]
+    start, end = [int(n) for n in coords.split('-')]
+
+    seq_length = (end - start) + 1
 
     # Call SLiM from command line with N and bottleneck proportion values
     # (passed as command-line arguments)
     outpath = "'" + outpath + "'"  # Required for command-line parsing and passing to SLiM
-    process = subprocess.Popen(["slim", "-s", "42", "-d", "N=" + str(N), "-d", "bot=" + str(bot), "-d", "outpath=" + str(outpath), slim_path],
+    process = subprocess.Popen(["slim", "-s", "42", "-d", "N=" + str(N), "-d", "bot=" + str(bot), "-d", "seq_length=" + str(seq_length), "-d", "outpath=" + str(outpath), slim_path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
                                universal_newlines=True)
@@ -161,7 +167,7 @@ if __name__ == "__main__":
     create_output_directory(outpath)
 
     # Run simulations
-    run_slim(N, bot, outpath, slim_path)
+    run_slim(N, bot, region, outpath, slim_path)
 
     # Sort VCFs
     sort_vcfs(outpath)

--- a/scripts/slim/Bottleneck.slim
+++ b/scripts/slim/Bottleneck.slim
@@ -8,7 +8,7 @@ initialize() {
 	initializeGenomicElementType("g1", m1, 1.0);
 	// uniform chromosome of length 100 Mb with uniform recombination
 	// chosen as the size of the Chlamydamonas genome
-	initializeGenomicElement(g1, 0, 1e6);
+	initializeGenomicElement(g1, 0, seq_length);
 	initializeRecombinationRate(1e-8);
 
 	// New population size following the bottleneck


### PR DESCRIPTION
Closes #26 

- Sequence length now calculated from `region` provided at command line. 
- Sequence length passed to SLiM script
- Sequence length and FASTA slicing in VCF to FASTA script now calculated from `region`