### PR TITLE
Run ldhelmet on server

### DIFF
--- a/scripts/batch/run_ldhelmet.sh
+++ b/scripts/batch/run_ldhelmet.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#SBATCH -N 1      # nodes requested
+#SBATCH -n 1      # tasks requested
+#SBATCH -c 30      # cores requested
+#SBATCH --mem=100000  # memory in Mb
+#SBATCH -o ldhelmet_outfile  # send stdout to outfile
+#SBATCH -e ldhelmet_errfile  # send stderr to errfile
+
+module load ldhelmet/1.10
+module load boost/1.6.5
+module load gsl/2.6
+
+sh ../shell/run-ldhelmet.sh ../../data/bottleneck/ ../../data/bottleneck/ldhelmet

--- a/scripts/batch/run_ldhelmet.sh
+++ b/scripts/batch/run_ldhelmet.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #SBATCH -N 1      # nodes requested
 #SBATCH -n 1      # tasks requested
-#SBATCH -c 30      # cores requested
+#SBATCH -c 50      # cores requested
 #SBATCH --mem=100000  # memory in Mb
 #SBATCH -o ldhelmet_outfile  # send stdout to outfile
 #SBATCH -e ldhelmet_errfile  # send stderr to errfile

--- a/scripts/shell/run-ldhelmet.sh
+++ b/scripts/shell/run-ldhelmet.sh
@@ -1,0 +1,72 @@
+inpath=$1
+outpath=$2
+
+mkdir -p ${outpath}
+
+find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
+    #echo $file
+    base=$(basename $fasta_file .fasta)
+    echo "Currently on ${base}"
+
+    time ldhelmet find_confs \
+    --num_threads 10 \
+    --window_size 50 \
+    --output_file ${outpath}/${base}.conf ${fasta_file}
+
+    sleep 1
+
+    echo "table_gen for ${base}"
+
+    time ldhelmet table_gen \
+    --num_threads 10 \
+    --conf_file ${outpath}/${base}.conf \
+    --theta 0.001 \
+    --rhos 0.0 0.1 10.0 1.0 100.0 \
+    --output_file ${outdir}/${base}.lk > table_gen 2> table_gen2
+    
+    sleep 1
+
+    rm table_gen*
+
+    sleep 1
+
+    time ldhelmet pade \
+    --num_threads 10 \
+    --conf_file ${outpath}/${base}.conf \
+    --theta 0.001 \
+    --output_file ${outdir}/${base}.pade
+
+    sleep 1
+
+    time ldhelmet rjmcmc \
+    --num_threads 30 \
+    --window_size 50 \
+    --seq_file ${fasta_file} \
+    --lk_file ${outdir}/${base}.lk \
+    --pade_file ${outdir}/${base}.pade \
+    --num_iter 1000000 \
+    --burn_in 100000 \
+    --block_penalty 50 \
+    --mut_mat_file ../../resources/mut_mat.txt \
+    --output_file ${outdir}/${base}.post
+
+    sleep 1
+
+    time ldhelmet post_to_text \
+    --mean \
+    --perc 0.025 \
+    --perc 0.50 \
+    --perc 0.975 \
+    --output_file ${outdir}/${base}.txt \
+    data/ldhelmet/${outdir}/${base}.post
+
+    sleep 3
+
+    echo "Removing temp files..."
+    rm ${outdir}/${base}.conf
+    rm ${outdir}/${base}.lk
+    rm ${outdir}/${base}.pade
+    rm ${outdir}/${base}.post
+
+done 
+

--- a/scripts/shell/run-ldhelmet.sh
+++ b/scripts/shell/run-ldhelmet.sh
@@ -4,12 +4,12 @@ outpath=$2
 mkdir -p ${outpath}
 
 find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
-    #echo $file
+#    echo $fasta_file
     base=$(basename $fasta_file .fasta)
     echo "Currently on ${base}"
 
     time ldhelmet find_confs \
-    --num_threads 10 \
+    --num_threads 50 \
     --window_size 50 \
     --output_file ${outpath}/${base}.conf ${fasta_file}
 
@@ -18,11 +18,11 @@ find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
     echo "table_gen for ${base}"
 
     time ldhelmet table_gen \
-    --num_threads 10 \
+    --num_threads 50 \
     --conf_file ${outpath}/${base}.conf \
     --theta 0.001 \
     --rhos 0.0 0.1 10.0 1.0 100.0 \
-    --output_file ${outdir}/${base}.lk > table_gen 2> table_gen2
+    --output_file ${outpath}/${base}.lk > table_gen 2> table_gen2
     
     sleep 1
 
@@ -31,10 +31,10 @@ find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
     sleep 1
 
     time ldhelmet pade \
-    --num_threads 10 \
+    --num_threads 50 \
     --conf_file ${outpath}/${base}.conf \
     --theta 0.001 \
-    --output_file ${outdir}/${base}.pade
+    --output_file ${outpath}/${base}.pade
 
     sleep 1
 
@@ -42,13 +42,13 @@ find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
     --num_threads 30 \
     --window_size 50 \
     --seq_file ${fasta_file} \
-    --lk_file ${outdir}/${base}.lk \
-    --pade_file ${outdir}/${base}.pade \
+    --lk_file ${outpath}/${base}.lk \
+    --pade_file ${outpath}/${base}.pade \
     --num_iter 1000000 \
     --burn_in 100000 \
     --block_penalty 50 \
     --mut_mat_file ../../resources/mut_mat.txt \
-    --output_file ${outdir}/${base}.post
+    --output_file ${outpath}/${base}.post
 
     sleep 1
 
@@ -57,16 +57,16 @@ find ${inpath} -name "*.fasta" -print0 | while read -d $'\0' fasta_file; do
     --perc 0.025 \
     --perc 0.50 \
     --perc 0.975 \
-    --output_file ${outdir}/${base}.txt \
-    data/ldhelmet/${outdir}/${base}.post
+    --output_file ${outpath}/${base}.txt \
+    data/ldhelmet/${outpath}/${base}.post
 
     sleep 3
 
     echo "Removing temp files..."
-    rm ${outdir}/${base}.conf
-    rm ${outdir}/${base}.lk
-    rm ${outdir}/${base}.pade
-    rm ${outdir}/${base}.post
+    rm ${outpath}/${base}.conf
+    rm ${outpath}/${base}.lk
+    rm ${outpath}/${base}.pade
+    rm ${outpath}/${base}.post
 
 done 
 


### PR DESCRIPTION
- Adding Ahmed's shell scripts to run LDhelmet with a couple of modifications:
    - The script recursively finds FASTA files downstream of `inpath`
    - `outpath` is provided by the user, and directories are created, of necessary
    - The block penalty is no longer passed at the command-line. Instead, it is fixed at 50 (for now)
- Adding batch script to run LDhelmet on cluster.